### PR TITLE
feat: add operator doctor and status commands

### DIFF
--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/bungeecord/BungeeCordListener.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/bungeecord/BungeeCordListener.java
@@ -100,6 +100,14 @@ public class BungeeCordListener extends AuthenticListeners<BungeeCordNexAuth, Pr
         // Note to future self: NEVER EVER RUN THIS ASYNC, IT WILL BREAK PLUGINS
 
         var profile = plugin.getDatabaseProvider().getByName(event.getConnection().getName());
+
+        if (profile == null) {
+            plugin.getLogger().error("Failed to retrieve profile for user: " + event.getConnection().getName() + " - database unavailable");
+            event.setCancelled(true);
+            event.setCancelReason("Authentication service temporarily unavailable. Please try again.");
+            return;
+        }
+
         PendingConnection connection = event.getConnection();
 
         try {
@@ -137,7 +145,10 @@ public class BungeeCordListener extends AuthenticListeners<BungeeCordNexAuth, Pr
                 event.setCancelled(false);
             } else {
                 try {
-                    var server = plugin.getServerHandler().chooseLobbyServer(plugin.getDatabaseProvider().getByUUID(player.getUniqueId()), player, false, true);
+                    var user = plugin.getDatabaseProvider().getByUUID(player.getUniqueId());
+                    if (user == null) throw new NoSuchElementException();
+
+                    var server = plugin.getServerHandler().chooseLobbyServer(user, player, false, true);
 
                     if (server == null) throw new NoSuchElementException();
 

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/AuthenticNexAuth.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/AuthenticNexAuth.java
@@ -204,6 +204,10 @@ public abstract class AuthenticNexAuth<P, S> implements NexAuthPlugin<P, S> {
         return databaseProvider;
     }
 
+    public DatabaseConnector<?, ?> getRuntimeDatabaseConnector() {
+        return databaseConnector;
+    }
+
     @Override
     public AuthenticPremiumProvider getPremiumProvider() {
         return premiumProvider;

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java
@@ -16,6 +16,12 @@ import xyz.xreatlabs.nexauth.api.event.events.AuthenticatedEvent;
 import xyz.xreatlabs.nexauth.common.AuthenticNexAuth;
 import xyz.xreatlabs.nexauth.common.command.InvalidCommandArgument;
 import xyz.xreatlabs.nexauth.common.database.AuthenticUser;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorJsonExporter;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorRenderer;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorService;
+import xyz.xreatlabs.nexauth.common.doctor.RenderedLine;
+import xyz.xreatlabs.nexauth.common.doctor.StatusRenderer;
+import xyz.xreatlabs.nexauth.common.doctor.StatusSnapshotProvider;
 import xyz.xreatlabs.nexauth.common.event.events.AuthenticPasswordChangeEvent;
 import xyz.xreatlabs.nexauth.common.event.events.AuthenticPremiumLoginSwitchEvent;
 import xyz.xreatlabs.nexauth.common.util.GeneralUtil;
@@ -60,6 +66,22 @@ public class NexAuthCommand<P> extends StaffCommand<P> {
             plugin.getEmailHandler().sendTestMail(email);
             audience.sendMessage(getMessage("info-sent-email"));
         });
+    }
+
+    @Subcommand("status")
+    @CommandPermission("nexauth.status")
+    @Syntax("{@@syntax.status}")
+    @CommandCompletion("%autocomplete.status")
+    public CompletionStage<Void> onStatus(Audience audience) {
+        return runAsync(() -> sendLines(audience, StatusRenderer.render(StatusSnapshotProvider.from(plugin))));
+    }
+
+    @Subcommand("doctor")
+    @CommandPermission("nexauth.doctor")
+    @Syntax("{@@syntax.doctor}")
+    @CommandCompletion("%autocomplete.doctor")
+    public CompletionStage<Void> onDoctor(Audience audience) {
+        return runAsync(() -> sendLines(audience, DoctorRenderer.render(DoctorService.forPlugin(plugin).run())));
     }
 
     @Subcommand("dump")
@@ -145,6 +167,10 @@ public class NexAuthCommand<P> extends StaffCommand<P> {
             var nexauth = new JsonObject();
             nexauth.addProperty("failurePolicyMode", plugin.getFailurePolicyMode().name());
             nexauth.add("authMetrics", plugin.getAuthMetrics().toJson());
+            var statusSnapshot = StatusSnapshotProvider.from(plugin);
+            var doctorReport = DoctorService.forPlugin(plugin).run();
+            nexauth.add("status", DoctorJsonExporter.exportStatus(statusSnapshot));
+            nexauth.add("doctor", DoctorJsonExporter.exportDoctor(doctorReport));
             dump.add("nexauth", nexauth);
 
             try (var writer = new FileWriter(dumpFile)) {
@@ -515,6 +541,12 @@ public class NexAuthCommand<P> extends StaffCommand<P> {
                 ));
             }
         });
+    }
+
+    private void sendLines(Audience audience, java.util.List<RenderedLine> lines) {
+        for (RenderedLine line : lines) {
+            audience.sendMessage(getMessage(line.messageKey(), line.replacements().toArray(String[]::new)));
+        }
     }
 
 }

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java
@@ -565,6 +565,55 @@ public class MessageKeys {
             ConfigurateHelper::getString
     );
 
+    public static final ConfigurationKey<String> INFO_STATUS_HEADER = new ConfigurationKey<>(
+            "info-status-header",
+            "NexAuth status for %platform% (%version%)",
+            "This message is displayed as the header for /nexauth status.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> INFO_STATUS_ENTRY = new ConfigurationKey<>(
+            "info-status-entry",
+            "%label%: %value%",
+            "This message is displayed for each status line in /nexauth status.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> INFO_STATUS_METRICS = new ConfigurationKey<>(
+            "info-status-metrics",
+            "Auth metrics: %json%",
+            "This message is displayed for metrics output in /nexauth status.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> INFO_DOCTOR_HEADER = new ConfigurationKey<>(
+            "info-doctor-header",
+            "NexAuth doctor summary: %severity%",
+            "This message is displayed as the header for /nexauth doctor.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> INFO_DOCTOR_ENTRY = new ConfigurationKey<>(
+            "info-doctor-entry",
+            "[%status%] %check%: %message%",
+            "This message is displayed for each doctor result line.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> INFO_DOCTOR_DETAIL = new ConfigurationKey<>(
+            "info-doctor-detail",
+            "  %detail%",
+            "This message is displayed for optional doctor detail lines.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> INFO_DOCTOR_SUMMARY = new ConfigurationKey<>(
+            "info-doctor-summary",
+            "Summary -> OK: %ok%, WARN: %warn%, FAIL: %fail%",
+            "This message is displayed as the summary line for /nexauth doctor.",
+            ConfigurateHelper::getString
+    );
+
     public static final ConfigurationKey<String> INFO_DELETING = new ConfigurationKey<>(
             "info-deleting",
             "Deleting...",
@@ -985,6 +1034,20 @@ public class MessageKeys {
             ConfigurateHelper::getString
     );
 
+    public static final ConfigurationKey<String> SYNTAX_STATUS = new ConfigurationKey<>(
+            "syntax.status",
+            "",
+            "This message is displayed when the player attempts to use /nexauth status with wrong syntax.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> SYNTAX_DOCTOR = new ConfigurationKey<>(
+            "syntax.doctor",
+            "",
+            "This message is displayed when the player attempts to use /nexauth doctor with wrong syntax.",
+            ConfigurateHelper::getString
+    );
+
     public static final ConfigurationKey<String> SYNTAX_SET_EMAIL = new ConfigurationKey<>(
             "syntax.set-email",
             "<address> <password>",
@@ -1155,6 +1218,20 @@ public class MessageKeys {
             "autocomplete.email-test",
             "address",
             "This hint is displayed when the player starts typing the /nexauth email test command.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> AUTOCOMPLETE_STATUS = new ConfigurationKey<>(
+            "autocomplete.status",
+            "",
+            "This hint is displayed when the player starts typing the /nexauth status command.",
+            ConfigurateHelper::getString
+    );
+
+    public static final ConfigurationKey<String> AUTOCOMPLETE_DOCTOR = new ConfigurationKey<>(
+            "autocomplete.doctor",
+            "",
+            "This hint is displayed when the player starts typing the /nexauth doctor command.",
             ConfigurateHelper::getString
     );
 

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheck.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheck.java
@@ -1,0 +1,7 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+@FunctionalInterface
+public interface DoctorCheck {
+
+    DoctorCheckResult run();
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResult.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResult.java
@@ -1,0 +1,33 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import java.util.Comparator;
+import java.util.Objects;
+
+public record DoctorCheckResult(
+        String checkId,
+        DoctorSeverity severity,
+        String message,
+        String detail,
+        String remediation
+) implements Comparable<DoctorCheckResult> {
+
+    private static final Comparator<DoctorCheckResult> ORDERING = Comparator
+            .comparingInt((DoctorCheckResult result) -> result.severity.ordinal()).reversed()
+            .thenComparing(DoctorCheckResult::checkId)
+            .thenComparing(DoctorCheckResult::message);
+
+    public DoctorCheckResult {
+        Objects.requireNonNull(checkId, "checkId");
+        Objects.requireNonNull(severity, "severity");
+        Objects.requireNonNull(message, "message");
+    }
+
+    public DoctorCheckResult(String checkId, DoctorSeverity severity, String message) {
+        this(checkId, severity, message, null, null);
+    }
+
+    @Override
+    public int compareTo(DoctorCheckResult other) {
+        return ORDERING.compare(this, other);
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorJsonExporter.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorJsonExporter.java
@@ -1,0 +1,74 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+
+public final class DoctorJsonExporter {
+
+    private static final Gson GSON = new Gson();
+
+    private DoctorJsonExporter() {
+    }
+
+    public static JsonObject export(StatusSnapshot status, DoctorReport doctor) {
+        var root = new JsonObject();
+        root.add("status", exportStatus(status));
+        root.add("doctor", exportDoctor(doctor));
+        return root;
+    }
+
+    public static JsonObject exportStatus(StatusSnapshot status) {
+        var json = new JsonObject();
+        json.addProperty("version", status.version());
+        json.addProperty("platform", status.platform());
+        json.addProperty("failurePolicyMode", status.failurePolicyMode());
+        json.addProperty("multiProxyEnabled", status.multiProxyEnabled());
+        json.addProperty("emailEnabled", status.emailEnabled());
+        json.addProperty("totpEnabled", status.totpEnabled());
+        json.addProperty("limboIntegrationAvailable", status.limboIntegrationAvailable());
+        if (status.proxyData() != null) {
+            json.add("proxyData", exportProxyData(status.proxyData()));
+        }
+        if (status.metrics() != null) {
+            json.add("metrics", status.metrics().deepCopy());
+        }
+        return json;
+    }
+
+    public static JsonObject exportDoctor(DoctorReport doctor) {
+        var json = new JsonObject();
+        json.addProperty("severity", doctor.overallSeverity().name());
+        json.addProperty("ok", doctor.okCount());
+        json.addProperty("warn", doctor.warnCount());
+        json.addProperty("fail", doctor.failCount());
+
+        var checks = new JsonArray();
+        for (DoctorCheckResult check : doctor.checks()) {
+            var item = new JsonObject();
+            item.addProperty("checkId", check.checkId());
+            item.addProperty("severity", check.severity().name());
+            item.addProperty("message", check.message());
+            if (check.detail() != null) {
+                item.addProperty("detail", check.detail());
+            }
+            if (check.remediation() != null) {
+                item.addProperty("remediation", check.remediation());
+            }
+            checks.add(item);
+        }
+        json.add("checks", checks);
+        return json;
+    }
+
+    private static JsonObject exportProxyData(PlatformHandle.ProxyData proxyData) {
+        var json = new JsonObject();
+        json.addProperty("name", proxyData.name());
+        json.add("servers", GSON.toJsonTree(proxyData.servers()));
+        json.add("plugins", GSON.toJsonTree(proxyData.plugins()));
+        json.add("limbos", GSON.toJsonTree(proxyData.limbos()));
+        json.add("lobbies", GSON.toJsonTree(proxyData.lobbies()));
+        return json;
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRenderer.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRenderer.java
@@ -1,0 +1,46 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class DoctorRenderer {
+
+    private DoctorRenderer() {
+    }
+
+    public static List<RenderedLine> render(DoctorReport report) {
+        return render(report, false);
+    }
+
+    public static List<RenderedLine> renderVerbose(DoctorReport report) {
+        return render(report, true);
+    }
+
+    private static List<RenderedLine> render(DoctorReport report, boolean verbose) {
+        var lines = new ArrayList<RenderedLine>();
+        lines.add(new RenderedLine("info-doctor-header", "%severity%", report.overallSeverity().name()));
+        for (DoctorCheckResult check : report.checks()) {
+            lines.add(new RenderedLine(
+                    "info-doctor-entry",
+                    "%status%", check.severity().name(),
+                    "%check%", check.checkId(),
+                    "%message%", check.message()
+            ));
+            if (verbose) {
+                if (check.detail() != null && !check.detail().isBlank()) {
+                    lines.add(new RenderedLine("info-doctor-detail", "%detail%", check.detail()));
+                }
+                if (check.remediation() != null && !check.remediation().isBlank()) {
+                    lines.add(new RenderedLine("info-doctor-detail", "%detail%", "Remediation: " + check.remediation()));
+                }
+            }
+        }
+        lines.add(new RenderedLine(
+                "info-doctor-summary",
+                "%ok%", Long.toString(report.okCount()),
+                "%warn%", Long.toString(report.warnCount()),
+                "%fail%", Long.toString(report.failCount())
+        ));
+        return List.copyOf(lines);
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorReport.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorReport.java
@@ -1,0 +1,38 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import java.util.List;
+import java.util.Objects;
+
+public record DoctorReport(List<DoctorCheckResult> checks) {
+
+    public DoctorReport {
+        Objects.requireNonNull(checks, "checks");
+        checks = checks.stream()
+                .sorted()
+                .toList();
+    }
+
+    public DoctorSeverity overallSeverity() {
+        return checks.stream()
+                .map(DoctorCheckResult::severity)
+                .reduce(DoctorSeverity.OK, DoctorSeverity::max);
+    }
+
+    public long okCount() {
+        return countBySeverity(DoctorSeverity.OK);
+    }
+
+    public long warnCount() {
+        return countBySeverity(DoctorSeverity.WARN);
+    }
+
+    public long failCount() {
+        return countBySeverity(DoctorSeverity.FAIL);
+    }
+
+    private long countBySeverity(DoctorSeverity severity) {
+        return checks.stream()
+                .filter(result -> result.severity() == severity)
+                .count();
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorService.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorService.java
@@ -1,0 +1,39 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import xyz.xreatlabs.nexauth.common.AuthenticNexAuth;
+import xyz.xreatlabs.nexauth.common.config.ConfigurationKeys;
+import xyz.xreatlabs.nexauth.common.doctor.checks.ConfigurationDoctorCheck;
+import xyz.xreatlabs.nexauth.common.doctor.checks.DatabaseDoctorCheck;
+import xyz.xreatlabs.nexauth.common.doctor.checks.IntegrationDoctorCheck;
+
+import java.util.List;
+import java.util.Objects;
+
+public record DoctorService(List<DoctorCheck> checks) {
+
+    public DoctorService {
+        Objects.requireNonNull(checks, "checks");
+        checks = List.copyOf(checks);
+    }
+
+    public static DoctorService forPlugin(AuthenticNexAuth<?, ?> plugin) {
+        var rawFailurePolicyMode = plugin.getConfiguration() == null
+                ? null
+                : plugin.getConfiguration().get(ConfigurationKeys.FAILURE_POLICY_MODE);
+
+        return new DoctorService(List.of(
+                new ConfigurationDoctorCheck(rawFailurePolicyMode),
+                new DatabaseDoctorCheck(plugin.getDatabaseProvider(), plugin.getRuntimeDatabaseConnector()),
+                new IntegrationDoctorCheck(
+                        plugin.getEmailHandler() != null,
+                        plugin.getTOTPProvider() != null,
+                        plugin.getLimboIntegration() != null,
+                        plugin.getPlatformHandle().getProxyData()
+                )
+        ));
+    }
+
+    public DoctorReport run() {
+        return new DoctorReport(checks.stream().map(DoctorCheck::run).toList());
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorSeverity.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorSeverity.java
@@ -1,0 +1,11 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+public enum DoctorSeverity {
+    OK,
+    WARN,
+    FAIL;
+
+    public static DoctorSeverity max(DoctorSeverity left, DoctorSeverity right) {
+        return left.ordinal() >= right.ordinal() ? left : right;
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/RenderedLine.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/RenderedLine.java
@@ -1,0 +1,16 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import java.util.List;
+import java.util.Objects;
+
+public record RenderedLine(String messageKey, List<String> replacements) {
+
+    public RenderedLine {
+        Objects.requireNonNull(messageKey, "messageKey");
+        Objects.requireNonNull(replacements, "replacements");
+    }
+
+    public RenderedLine(String messageKey, String... replacements) {
+        this(messageKey, List.of(replacements));
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusRenderer.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusRenderer.java
@@ -1,0 +1,35 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class StatusRenderer {
+
+    private StatusRenderer() {
+    }
+
+    public static List<RenderedLine> render(StatusSnapshot snapshot) {
+        var lines = new ArrayList<RenderedLine>();
+        lines.add(new RenderedLine("info-status-header", "%version%", snapshot.version(), "%platform%", snapshot.platform()));
+        lines.add(new RenderedLine("info-status-entry", "%label%", "Failure policy", "%value%", snapshot.failurePolicyMode()));
+        lines.add(new RenderedLine("info-status-entry", "%label%", "Multi-proxy", "%value%", enabled(snapshot.multiProxyEnabled())));
+        lines.add(new RenderedLine("info-status-entry", "%label%", "Email", "%value%", enabled(snapshot.emailEnabled())));
+        lines.add(new RenderedLine("info-status-entry", "%label%", "TOTP", "%value%", enabled(snapshot.totpEnabled())));
+        lines.add(new RenderedLine("info-status-entry", "%label%", "Limbo integration", "%value%", available(snapshot.limboIntegrationAvailable())));
+        if (snapshot.proxyData() != null) {
+            lines.add(new RenderedLine("info-status-entry", "%label%", "Proxy", "%value%", snapshot.proxyData().name()));
+        }
+        if (snapshot.metrics() != null) {
+            lines.add(new RenderedLine("info-status-metrics", "%json%", snapshot.metrics().toString()));
+        }
+        return List.copyOf(lines);
+    }
+
+    private static String enabled(boolean value) {
+        return value ? "Enabled" : "Disabled";
+    }
+
+    private static String available(boolean value) {
+        return value ? "Available" : "Unavailable";
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshot.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshot.java
@@ -1,0 +1,17 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import com.google.gson.JsonObject;
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+
+public record StatusSnapshot(
+        String version,
+        String platform,
+        String failurePolicyMode,
+        boolean multiProxyEnabled,
+        boolean emailEnabled,
+        boolean totpEnabled,
+        boolean limboIntegrationAvailable,
+        PlatformHandle.ProxyData proxyData,
+        JsonObject metrics
+) {
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshotProvider.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshotProvider.java
@@ -1,0 +1,45 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import com.google.gson.JsonObject;
+import xyz.xreatlabs.nexauth.common.AuthenticNexAuth;
+
+public record StatusSnapshotProvider(
+        String version,
+        String platform,
+        String failurePolicyMode,
+        boolean multiProxyEnabled,
+        boolean emailEnabled,
+        boolean totpEnabled,
+        boolean limboIntegrationAvailable,
+        xyz.xreatlabs.nexauth.api.PlatformHandle.ProxyData proxyData,
+        JsonObject metrics
+) {
+
+    public static StatusSnapshot from(AuthenticNexAuth<?, ?> plugin) {
+        return new StatusSnapshotProvider(
+                plugin.getVersion(),
+                plugin.getPlatformHandle().getPlatformIdentifier(),
+                plugin.getFailurePolicyMode().name(),
+                plugin.multiProxyEnabled(),
+                plugin.getEmailHandler() != null,
+                plugin.getTOTPProvider() != null,
+                plugin.getLimboIntegration() != null,
+                plugin.getPlatformHandle().getProxyData(),
+                plugin.getAuthMetrics().toJson()
+        ).create();
+    }
+
+    public StatusSnapshot create() {
+        return new StatusSnapshot(
+                version,
+                platform,
+                failurePolicyMode,
+                multiProxyEnabled,
+                emailEnabled,
+                totpEnabled,
+                limboIntegrationAvailable,
+                proxyData,
+                metrics
+        );
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheck.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheck.java
@@ -1,0 +1,39 @@
+package xyz.xreatlabs.nexauth.common.doctor.checks;
+
+import xyz.xreatlabs.nexauth.common.doctor.DoctorCheck;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorCheckResult;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorSeverity;
+import xyz.xreatlabs.nexauth.common.reliability.FailurePolicyMode;
+
+import java.util.Arrays;
+
+public record ConfigurationDoctorCheck(String rawFailurePolicyMode) implements DoctorCheck {
+
+    @Override
+    public DoctorCheckResult run() {
+        if (rawFailurePolicyMode == null || rawFailurePolicyMode.isBlank()) {
+            return new DoctorCheckResult(
+                    "configuration",
+                    DoctorSeverity.WARN,
+                    "Failure policy mode missing, using HARD_FAIL",
+                    "Resolved mode: HARD_FAIL",
+                    "Set failure-policy.mode to HARD_FAIL, RETRY_THEN_DISABLE, or DEGRADE"
+            );
+        }
+
+        var normalized = rawFailurePolicyMode.trim().toUpperCase();
+        var recognized = Arrays.stream(FailurePolicyMode.values()).anyMatch(mode -> mode.name().equals(normalized));
+
+        if (!recognized) {
+            return new DoctorCheckResult(
+                    "configuration",
+                    DoctorSeverity.WARN,
+                    "Unknown failure policy mode '" + rawFailurePolicyMode + "', using HARD_FAIL",
+                    "Resolved mode: HARD_FAIL",
+                    "Set failure-policy.mode to HARD_FAIL, RETRY_THEN_DISABLE, or DEGRADE"
+            );
+        }
+
+        return new DoctorCheckResult("configuration", DoctorSeverity.OK, "Failure policy mode set to " + normalized);
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheck.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheck.java
@@ -1,0 +1,42 @@
+package xyz.xreatlabs.nexauth.common.doctor.checks;
+
+import xyz.xreatlabs.nexauth.api.database.ReadWriteDatabaseProvider;
+import xyz.xreatlabs.nexauth.api.database.connector.DatabaseConnector;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorCheck;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorCheckResult;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorSeverity;
+
+public record DatabaseDoctorCheck(ReadWriteDatabaseProvider provider, DatabaseConnector<?, ?> connector) implements DoctorCheck {
+
+    @Override
+    public DoctorCheckResult run() {
+        if (provider == null) {
+            return new DoctorCheckResult(
+                    "database",
+                    DoctorSeverity.FAIL,
+                    "Database provider unavailable",
+                    "No active ReadWriteDatabaseProvider is registered",
+                    "Check database.type and connector initialization during startup"
+            );
+        }
+        if (connector == null) {
+            return new DoctorCheckResult(
+                    "database",
+                    DoctorSeverity.WARN,
+                    "Database connector unavailable",
+                    "Read/write provider exists without an exposed runtime connector",
+                    "Verify the configured provider exposes a connector for health checks"
+            );
+        }
+        if (!connector.connected()) {
+            return new DoctorCheckResult(
+                    "database",
+                    DoctorSeverity.FAIL,
+                    "Database connector is disconnected",
+                    "Observed connector state: disconnected",
+                    "Verify database credentials and restart NexAuth"
+            );
+        }
+        return new DoctorCheckResult("database", DoctorSeverity.OK, "Database provider and connector are ready");
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheck.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheck.java
@@ -1,0 +1,57 @@
+package xyz.xreatlabs.nexauth.common.doctor.checks;
+
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorCheck;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorCheckResult;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorSeverity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record IntegrationDoctorCheck(
+        boolean emailAvailable,
+        boolean totpAvailable,
+        boolean limboAvailable,
+        PlatformHandle.ProxyData proxyData
+) implements DoctorCheck {
+
+    @Override
+    public DoctorCheckResult run() {
+        if (proxyData == null) {
+            return new DoctorCheckResult(
+                    "integration",
+                    DoctorSeverity.FAIL,
+                    "Proxy data unavailable",
+                    "Platform handle returned null proxy metadata",
+                    "Verify platform bootstrap completed before running diagnostics"
+            );
+        }
+
+        var unavailable = new ArrayList<String>();
+        if (!emailAvailable) unavailable.add("Email");
+        if (!totpAvailable) unavailable.add("TOTP");
+        if (!limboAvailable) unavailable.add("limbo");
+
+        if (!unavailable.isEmpty()) {
+            return new DoctorCheckResult(
+                    "integration",
+                    DoctorSeverity.WARN,
+                    joinUnavailable(unavailable) + " integrations are unavailable",
+                    "Available proxy: " + proxyData.name(),
+                    "Install or configure the missing integrations if your deployment expects them"
+            );
+        }
+
+        return new DoctorCheckResult("integration", DoctorSeverity.OK, "Core integrations and proxy data are available");
+    }
+
+    private static String joinUnavailable(List<String> unavailable) {
+        if (unavailable.size() == 1) {
+            return unavailable.getFirst();
+        }
+        if (unavailable.size() == 2) {
+            return unavailable.getFirst() + " and " + unavailable.get(1);
+        }
+        return String.join(", ", unavailable.subList(0, unavailable.size() - 1)) + ", and " + unavailable.getLast();
+    }
+}

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/paper/PaperListeners.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/paper/PaperListeners.java
@@ -134,6 +134,12 @@ public class PaperListeners extends AuthenticListeners<PaperNexAuth, Player, Wor
 
         var user = plugin.getDatabaseProvider().getByName(event.getName());
 
+        if (user == null) {
+            plugin.getLogger().error("Failed to retrieve profile for user: " + event.getName() + " - database unavailable");
+            event.disallow(AsyncPlayerPreLoginEvent.Result.KICK_OTHER, Component.text("Authentication service temporarily unavailable. Please try again."));
+            return;
+        }
+
         var newProfile = Bukkit.createProfileExact(user.getUuid(), event.getName());
 
         event.setPlayerProfile(newProfile);

--- a/Plugin/src/main/java/xyz/xreatlabs/nexauth/velocity/VelocityListeners.java
+++ b/Plugin/src/main/java/xyz/xreatlabs/nexauth/velocity/VelocityListeners.java
@@ -96,6 +96,11 @@ public class VelocityListeners extends AuthenticListeners<VelocityNexAuth, Playe
 
         var profile = plugin.getDatabaseProvider().getByName(event.getUsername());
 
+        if (profile == null) {
+            plugin.getLogger().error("Failed to retrieve profile for user: " + event.getUsername() + " - database unavailable");
+            return;
+        }
+
         var gProfile = event.getOriginalProfile();
 
         event.setGameProfile(new GameProfile(profile.getUuid(), gProfile.getName(), gProfile.getProperties()));
@@ -171,7 +176,10 @@ public class VelocityListeners extends AuthenticListeners<VelocityNexAuth, Playe
                 event.setResult(KickedFromServerEvent.DisconnectPlayer.create(message));
             } else {
                 try {
-                    var server = plugin.getServerHandler().chooseLobbyServer(plugin.getDatabaseProvider().getByUUID(player.getUniqueId()), player, false, true);
+                    var user = plugin.getDatabaseProvider().getByUUID(player.getUniqueId());
+                    if (user == null) throw new NoSuchElementException();
+
+                    var server = plugin.getServerHandler().chooseLobbyServer(user, player, false, true);
 
                     if (server == null) throw new NoSuchElementException();
 

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResultTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResultTest.java
@@ -1,0 +1,29 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DoctorCheckResultTest {
+
+    @Test
+    void severityUsesExpectedOrdering() {
+        assertTrue(DoctorSeverity.OK.compareTo(DoctorSeverity.WARN) < 0);
+        assertTrue(DoctorSeverity.WARN.compareTo(DoctorSeverity.FAIL) < 0);
+    }
+
+    @Test
+    void compareToSortsBySeverityThenCheckId() {
+        var fail = new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database unreachable");
+        var warn = new DoctorCheckResult("config", DoctorSeverity.WARN, "Configuration fallback active");
+        var ok = new DoctorCheckResult("email", DoctorSeverity.OK, "Email ready");
+        var warnLater = new DoctorCheckResult("premium", DoctorSeverity.WARN, "Premium provider reachable");
+
+        var sorted = java.util.stream.Stream.of(ok, warnLater, fail, warn)
+                .sorted()
+                .toList();
+
+        assertEquals(java.util.List.of(fail, warn, warnLater, ok), sorted);
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorJsonExporterTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorJsonExporterTest.java
@@ -1,0 +1,47 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoctorJsonExporterTest {
+
+    @Test
+    void exportsStatusAndDoctorSections() {
+        var metrics = new JsonObject();
+        metrics.addProperty("total", 4);
+        var status = new StatusSnapshot(
+                "0.0.1-beta3",
+                "velocity",
+                "DEGRADE",
+                true,
+                true,
+                false,
+                true,
+                new PlatformHandle.ProxyData("proxy-1", List.of("survival"), List.of("NexAuth"), List.of("limbo"), List.of("lobby")),
+                metrics
+        );
+        var doctor = new DoctorReport(List.of(
+                new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database connector is disconnected", "Observed connector state: disconnected", "Verify database credentials and restart NexAuth"),
+                new DoctorCheckResult("configuration", DoctorSeverity.WARN, "Unknown failure policy mode 'mystery-mode', using HARD_FAIL")
+        ));
+
+        var json = DoctorJsonExporter.export(status, doctor);
+
+        assertEquals("0.0.1-beta3", json.getAsJsonObject("status").get("version").getAsString());
+        assertEquals("DEGRADE", json.getAsJsonObject("status").get("failurePolicyMode").getAsString());
+        assertEquals(4, json.getAsJsonObject("status").getAsJsonObject("metrics").get("total").getAsLong());
+
+        var doctorJson = json.getAsJsonObject("doctor");
+        assertEquals("FAIL", doctorJson.get("severity").getAsString());
+        assertEquals(0, doctorJson.get("ok").getAsLong());
+        assertEquals(1, doctorJson.get("warn").getAsLong());
+        assertEquals(1, doctorJson.get("fail").getAsLong());
+        assertEquals(2, doctorJson.getAsJsonArray("checks").size());
+        assertEquals("Verify database credentials and restart NexAuth", doctorJson.getAsJsonArray("checks").get(0).getAsJsonObject().get("remediation").getAsString());
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRemediationTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRemediationTest.java
@@ -1,0 +1,31 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoctorRemediationTest {
+
+    @Test
+    void verboseRendererIncludesDetailAndRemediationLines() {
+        var report = new DoctorReport(List.of(
+                new DoctorCheckResult(
+                        "database",
+                        DoctorSeverity.FAIL,
+                        "Database connector is disconnected",
+                        "Observed connector state: disconnected",
+                        "Verify database credentials and restart NexAuth"
+                )
+        ));
+
+        assertEquals(List.of(
+                new RenderedLine("info-doctor-header", "%severity%", "FAIL"),
+                new RenderedLine("info-doctor-entry", "%status%", "FAIL", "%check%", "database", "%message%", "Database connector is disconnected"),
+                new RenderedLine("info-doctor-detail", "%detail%", "Observed connector state: disconnected"),
+                new RenderedLine("info-doctor-detail", "%detail%", "Remediation: Verify database credentials and restart NexAuth"),
+                new RenderedLine("info-doctor-summary", "%ok%", "0", "%warn%", "0", "%fail%", "1")
+        ), DoctorRenderer.renderVerbose(report));
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRendererTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRendererTest.java
@@ -1,0 +1,38 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoctorRendererTest {
+
+    @Test
+    void rendersOrderedDoctorResultsAndSummary() {
+        var report = new DoctorReport(List.of(
+                new DoctorCheckResult("email", DoctorSeverity.OK, "Email ready"),
+                new DoctorCheckResult("config", DoctorSeverity.WARN, "Configuration fallback active"),
+                new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database unreachable")
+        ));
+
+        var rendered = DoctorRenderer.render(report);
+
+        assertEquals(List.of(
+                new RenderedLine("info-doctor-header", "%severity%", "FAIL"),
+                new RenderedLine("info-doctor-entry", "%status%", "FAIL", "%check%", "database", "%message%", "Database unreachable"),
+                new RenderedLine("info-doctor-entry", "%status%", "WARN", "%check%", "config", "%message%", "Configuration fallback active"),
+                new RenderedLine("info-doctor-entry", "%status%", "OK", "%check%", "email", "%message%", "Email ready"),
+                new RenderedLine("info-doctor-summary", "%ok%", "1", "%warn%", "1", "%fail%", "1")
+        ), rendered);
+    }
+
+    @Test
+    void verboseRenderingMatchesNormalRenderingUntilDetailsExist() {
+        var report = new DoctorReport(List.of(
+                new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database unreachable")
+        ));
+
+        assertEquals(DoctorRenderer.render(report), DoctorRenderer.renderVerbose(report));
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorReportTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorReportTest.java
@@ -1,0 +1,47 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoctorReportTest {
+
+    @Test
+    void derivesSummaryCountsAndOverallSeverity() {
+        var report = new DoctorReport(List.of(
+                new DoctorCheckResult("email", DoctorSeverity.OK, "Email ready"),
+                new DoctorCheckResult("config", DoctorSeverity.WARN, "Configuration fallback active"),
+                new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database unreachable"),
+                new DoctorCheckResult("premium", DoctorSeverity.WARN, "Premium provider slow")
+        ));
+
+        assertEquals(DoctorSeverity.FAIL, report.overallSeverity());
+        assertEquals(1, report.okCount());
+        assertEquals(2, report.warnCount());
+        assertEquals(1, report.failCount());
+    }
+
+    @Test
+    void sortsChecksDeterministically() {
+        var ok = new DoctorCheckResult("email", DoctorSeverity.OK, "Email ready");
+        var warn = new DoctorCheckResult("config", DoctorSeverity.WARN, "Configuration fallback active");
+        var fail = new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database unreachable");
+        var warnLater = new DoctorCheckResult("premium", DoctorSeverity.WARN, "Premium provider reachable");
+
+        var report = new DoctorReport(List.of(ok, warnLater, fail, warn));
+
+        assertEquals(List.of(fail, warn, warnLater, ok), report.checks());
+    }
+
+    @Test
+    void emptyReportDefaultsToOkSeverity() {
+        var report = new DoctorReport(List.of());
+
+        assertEquals(DoctorSeverity.OK, report.overallSeverity());
+        assertEquals(0, report.okCount());
+        assertEquals(0, report.warnCount());
+        assertEquals(0, report.failCount());
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorServiceTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorServiceTest.java
@@ -1,0 +1,24 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DoctorServiceTest {
+
+    @Test
+    void runsChecksIntoOrderedReport() {
+        var service = new DoctorService(List.<DoctorCheck>of(
+                () -> new DoctorCheckResult("email", DoctorSeverity.OK, "Email ready"),
+                () -> new DoctorCheckResult("database", DoctorSeverity.FAIL, "Database unreachable"),
+                () -> new DoctorCheckResult("config", DoctorSeverity.WARN, "Configuration fallback active")
+        ));
+
+        var report = service.run();
+
+        assertEquals(DoctorSeverity.FAIL, report.overallSeverity());
+        assertEquals(List.of("database", "config", "email"), report.checks().stream().map(DoctorCheckResult::checkId).toList());
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/MessageKeySmokeTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/MessageKeySmokeTest.java
@@ -1,0 +1,29 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MessageKeySmokeTest {
+
+    @Test
+    void definesDoctorAndStatusMessageKeys() throws IOException {
+        var source = Files.readString(Path.of("src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java"));
+
+        assertTrue(source.contains("INFO_STATUS_HEADER"));
+        assertTrue(source.contains("INFO_STATUS_ENTRY"));
+        assertTrue(source.contains("INFO_STATUS_METRICS"));
+        assertTrue(source.contains("INFO_DOCTOR_HEADER"));
+        assertTrue(source.contains("INFO_DOCTOR_ENTRY"));
+        assertTrue(source.contains("INFO_DOCTOR_DETAIL"));
+        assertTrue(source.contains("INFO_DOCTOR_SUMMARY"));
+        assertTrue(source.contains("SYNTAX_STATUS"));
+        assertTrue(source.contains("SYNTAX_DOCTOR"));
+        assertTrue(source.contains("AUTOCOMPLETE_STATUS"));
+        assertTrue(source.contains("AUTOCOMPLETE_DOCTOR"));
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/StatusRendererTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/StatusRendererTest.java
@@ -1,0 +1,50 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StatusRendererTest {
+
+    @Test
+    void rendersCompactStatusSummaryLines() {
+        var metrics = new JsonObject();
+        metrics.addProperty("total", 7);
+        var proxyData = new PlatformHandle.ProxyData(
+                "proxy-1",
+                List.of("survival", "lobby"),
+                List.of("NexAuth"),
+                List.of("limbo"),
+                List.of("lobby")
+        );
+        var snapshot = new StatusSnapshot(
+                "0.0.1-beta3",
+                "velocity",
+                "DEGRADE",
+                true,
+                true,
+                false,
+                true,
+                proxyData,
+                metrics
+        );
+
+        var rendered = StatusRenderer.render(snapshot);
+
+        assertEquals("info-status-header", rendered.getFirst().messageKey());
+        assertEquals(List.of("%version%", "0.0.1-beta3", "%platform%", "velocity"), rendered.getFirst().replacements());
+        assertEquals(List.of(
+                new RenderedLine("info-status-entry", "%label%", "Failure policy", "%value%", "DEGRADE"),
+                new RenderedLine("info-status-entry", "%label%", "Multi-proxy", "%value%", "Enabled"),
+                new RenderedLine("info-status-entry", "%label%", "Email", "%value%", "Enabled"),
+                new RenderedLine("info-status-entry", "%label%", "TOTP", "%value%", "Disabled"),
+                new RenderedLine("info-status-entry", "%label%", "Limbo integration", "%value%", "Available"),
+                new RenderedLine("info-status-entry", "%label%", "Proxy", "%value%", "proxy-1"),
+                new RenderedLine("info-status-metrics", "%json%", metrics.toString())
+        ), rendered.subList(1, rendered.size()));
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshotProviderTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshotProviderTest.java
@@ -1,0 +1,65 @@
+package xyz.xreatlabs.nexauth.common.doctor;
+
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StatusSnapshotProviderTest {
+
+    @Test
+    void buildsSnapshotFromProvidedState() {
+        var metrics = new JsonObject();
+        metrics.addProperty("total", 3);
+        var provider = new StatusSnapshotProvider(
+                "0.0.1-beta3",
+                "test-platform",
+                "DEGRADE",
+                true,
+                true,
+                true,
+                true,
+                new PlatformHandle.ProxyData("proxy-test", List.of("lobby"), List.of("NexAuth"), List.of("limbo"), List.of("lobby")),
+                metrics
+        );
+
+        var snapshot = provider.create();
+
+        assertEquals("0.0.1-beta3", snapshot.version());
+        assertEquals("test-platform", snapshot.platform());
+        assertEquals("DEGRADE", snapshot.failurePolicyMode());
+        assertTrue(snapshot.multiProxyEnabled());
+        assertTrue(snapshot.emailEnabled());
+        assertTrue(snapshot.totpEnabled());
+        assertTrue(snapshot.limboIntegrationAvailable());
+        assertEquals("proxy-test", snapshot.proxyData().name());
+        assertEquals(3, snapshot.metrics().get("total").getAsLong());
+    }
+
+    @Test
+    void preservesUnavailableOptionalSystems() {
+        var provider = new StatusSnapshotProvider(
+                "0.0.1-beta3",
+                "test-platform",
+                "HARD_FAIL",
+                false,
+                false,
+                false,
+                false,
+                null,
+                null
+        );
+
+        var snapshot = provider.create();
+
+        assertFalse(snapshot.multiProxyEnabled());
+        assertFalse(snapshot.emailEnabled());
+        assertFalse(snapshot.totpEnabled());
+        assertFalse(snapshot.limboIntegrationAvailable());
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheckTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheckTest.java
@@ -1,0 +1,26 @@
+package xyz.xreatlabs.nexauth.common.doctor.checks;
+
+import org.junit.jupiter.api.Test;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorSeverity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ConfigurationDoctorCheckTest {
+
+    @Test
+    void warnsWhenFailurePolicyModeIsUnknown() {
+        var result = new ConfigurationDoctorCheck("mystery-mode").run();
+
+        assertEquals("configuration", result.checkId());
+        assertEquals(DoctorSeverity.WARN, result.severity());
+        assertEquals("Unknown failure policy mode 'mystery-mode', using HARD_FAIL", result.message());
+    }
+
+    @Test
+    void reportsOkWhenFailurePolicyModeIsRecognized() {
+        var result = new ConfigurationDoctorCheck("DEGRADE").run();
+
+        assertEquals(DoctorSeverity.OK, result.severity());
+        assertEquals("Failure policy mode set to DEGRADE", result.message());
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheckTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheckTest.java
@@ -1,0 +1,68 @@
+package xyz.xreatlabs.nexauth.common.doctor.checks;
+
+import org.junit.jupiter.api.Test;
+import xyz.xreatlabs.nexauth.api.database.ReadWriteDatabaseProvider;
+import xyz.xreatlabs.nexauth.api.database.User;
+import xyz.xreatlabs.nexauth.api.database.connector.DatabaseConnector;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorSeverity;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DatabaseDoctorCheckTest {
+
+    @Test
+    void failsWhenDatabaseProviderIsMissing() {
+        var result = new DatabaseDoctorCheck(null, null).run();
+
+        assertEquals(DoctorSeverity.FAIL, result.severity());
+        assertEquals("Database provider unavailable", result.message());
+    }
+
+    @Test
+    void warnsWhenConnectorIsUnavailable() {
+        var result = new DatabaseDoctorCheck(new TestDatabaseProvider(), null).run();
+
+        assertEquals(DoctorSeverity.WARN, result.severity());
+        assertEquals("Database connector unavailable", result.message());
+    }
+
+    @Test
+    void failsWhenConnectorIsDisconnected() {
+        var result = new DatabaseDoctorCheck(new TestDatabaseProvider(), new TestDatabaseConnector(false)).run();
+
+        assertEquals(DoctorSeverity.FAIL, result.severity());
+        assertEquals("Database connector is disconnected", result.message());
+    }
+
+    @Test
+    void reportsOkWhenProviderAndConnectorAreReady() {
+        var result = new DatabaseDoctorCheck(new TestDatabaseProvider(), new TestDatabaseConnector(true)).run();
+
+        assertEquals(DoctorSeverity.OK, result.severity());
+        assertEquals("Database provider and connector are ready", result.message());
+    }
+
+    private static final class TestDatabaseProvider implements ReadWriteDatabaseProvider {
+        @Override public User getByName(String name) { return null; }
+        @Override public User getByUUID(UUID uuid) { return null; }
+        @Override public User getByPremiumUUID(UUID uuid) { return null; }
+        @Override public Collection<User> getAllUsers() { return List.of(); }
+        @Override public Collection<User> getByIP(String ip) { return List.of(); }
+        @Override public void insertUser(User user) { }
+        @Override public void insertUsers(Collection<User> users) { }
+        @Override public void updateUser(User user) { }
+        @Override public void deleteUser(User user) { }
+    }
+
+    private record TestDatabaseConnector(boolean connected) implements DatabaseConnector<RuntimeException, Object> {
+        @Override public void connect() { }
+        @Override public boolean connected() { return connected; }
+        @Override public void disconnect() { }
+        @Override public Object obtainInterface() { return new Object(); }
+        @Override public <V> V runQuery(xyz.xreatlabs.nexauth.api.util.ThrowableFunction<Object, V, RuntimeException> function) { return null; }
+    }
+}

--- a/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheckTest.java
+++ b/Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheckTest.java
@@ -1,0 +1,36 @@
+package xyz.xreatlabs.nexauth.common.doctor.checks;
+
+import org.junit.jupiter.api.Test;
+import xyz.xreatlabs.nexauth.api.PlatformHandle;
+import xyz.xreatlabs.nexauth.common.doctor.DoctorSeverity;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class IntegrationDoctorCheckTest {
+
+    @Test
+    void failsWhenProxyDataIsUnavailable() {
+        var result = new IntegrationDoctorCheck(true, true, true, null).run();
+
+        assertEquals(DoctorSeverity.FAIL, result.severity());
+        assertEquals("Proxy data unavailable", result.message());
+    }
+
+    @Test
+    void warnsWhenOptionalIntegrationsAreUnavailable() {
+        var result = new IntegrationDoctorCheck(false, false, false, new PlatformHandle.ProxyData("proxy", List.of(), List.of(), List.of(), List.of())).run();
+
+        assertEquals(DoctorSeverity.WARN, result.severity());
+        assertEquals("Email, TOTP, and limbo integrations are unavailable", result.message());
+    }
+
+    @Test
+    void reportsOkWhenIntegrationsAndProxyDataAreAvailable() {
+        var result = new IntegrationDoctorCheck(true, true, true, new PlatformHandle.ProxyData("proxy", List.of(), List.of(), List.of(), List.of())).run();
+
+        assertEquals(DoctorSeverity.OK, result.severity());
+        assertEquals("Core integrations and proxy data are available", result.message());
+    }
+}

--- a/docs/plans/2026-03-11-doctor-status-system.md
+++ b/docs/plans/2026-03-11-doctor-status-system.md
@@ -1,0 +1,526 @@
+# Doctor/Status System Implementation Plan
+
+> **REQUIRED SUB-SKILL:** Use the executing-plans skill to implement this plan task-by-task.
+
+**Goal:** Add a phased operator-facing `/nexauth status` and `/nexauth doctor` system that starts with a minimal command shell, grows into MVP health checks, and finishes with support-heavy diagnostics and dump integration.
+
+**Architecture:** Keep command wiring thin inside `NexAuthCommand`, and move status/doctor logic into a dedicated `xyz.xreatlabs.nexauth.common.doctor` package made of small immutable models, snapshot builders, health checks, and renderers. Build the feature in phases so each phase ships usable behavior: first the shell and renderer, then MVP checks, then richer support/report integration. Prefer pure unit-tested services and renderers over platform-heavy command or runtime integration tests.
+
+**Tech Stack:** Gradle multi-module build, Java 21, JUnit 5, Adventure components/messages, ACF command framework, existing `AuthMetrics`, `FailurePolicyMode`, `PlatformHandle.ProxyData`, and dump command infrastructure.
+
+---
+
+## Phase Overview
+
+### Phase 0 — Workspace + planning handoff
+- Create a clean feature branch or worktree after the existing stash.
+- Keep the existing stash (`pre-doctor-status-implementation`) intact until the feature branch is ready.
+- Use subagents for focused execution by phase, not for final verification.
+
+### Phase 1 — Minimal command shell
+- Add the doctor/status package and base result/report/renderer types.
+- Add `/nexauth status` and `/nexauth doctor` commands with simple summary output.
+- Add message keys and command syntax/autocomplete entries.
+
+### Phase 2 — MVP operator checks
+- Add health snapshots and checks for configuration, integrations, and auth state.
+- Expand status output with runtime/config summary and metrics.
+- Expand doctor output with `OK/WARN/FAIL` results and a summary line.
+
+### Phase 3 — Support-heavy diagnostics
+- Add remediation hints and verbose detail rendering.
+- Integrate doctor/status data into `/nexauth dump` JSON.
+- Add redaction-safe diagnostic sections for support workflows.
+
+### Phase 4 — Verification + polish
+- Run focused tests during each phase.
+- Run final module test verification.
+- Optionally request review before merge.
+
+---
+
+## Recommended subagent execution model
+
+Use one subagent batch per phase after planning:
+
+1. **Phase 1 subagent batch**
+   - Agent A: implement base models + renderers + tests
+   - Agent B: add command wiring + message keys + tests
+2. **Phase 2 subagent batch**
+   - Agent A: implement status snapshot builder + tests
+   - Agent B: implement MVP health checks + tests
+3. **Phase 3 subagent batch**
+   - Agent A: integrate dump JSON/report rendering
+   - Agent B: add remediation hints/polish + docs updates if needed
+4. **Lead agent responsibilities**
+   - review diffs between phases
+   - resolve merge conflicts
+   - run authoritative verification commands yourself
+
+Do **not** let subagents claim completion without fresh local verification in the lead session.
+
+---
+
+### Task 1: Establish doctor package foundation
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorSeverity.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResult.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorReport.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheck.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResultTest.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorReportTest.java`
+
+**Step 1: Write the failing tests**
+
+Add tests that define:
+- severity ordering / semantics (`OK`, `WARN`, `FAIL`)
+- `DoctorReport` summary counts
+- overall report severity derivation
+- deterministic check ordering if the report sorts checks
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorCheckResultTest' --tests '*DoctorReportTest'
+```
+Expected: failing tests because the doctor model classes do not exist yet.
+
+**Step 3: Write minimal production code**
+
+Implement the smallest immutable model types needed to satisfy the tests.
+
+**Step 4: Run the focused tests to verify they pass**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorCheckResultTest' --tests '*DoctorReportTest'
+```
+Expected: all focused tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add doctor report foundation"
+```
+
+---
+
+### Task 2: Add text renderers for status and doctor output
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshot.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusRenderer.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRenderer.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/StatusRendererTest.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRendererTest.java`
+
+**Step 1: Write the failing tests**
+
+Define expected rendered lines for:
+- a minimal status snapshot
+- a doctor report with mixed `OK/WARN/FAIL` results
+- summary line formatting
+- optional detail/hint lines in verbose rendering hooks (the hooks may be no-op in this phase)
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*StatusRendererTest' --tests '*DoctorRendererTest'
+```
+Expected: failing tests because the renderers do not exist yet.
+
+**Step 3: Write minimal production code**
+
+Implement renderers that return ordered line lists or simple value objects for command emission. Keep them independent from `Audience` so they stay easy to test.
+
+**Step 4: Run the focused tests to verify they pass**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*StatusRendererTest' --tests '*DoctorRendererTest'
+```
+Expected: all focused tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add doctor and status renderers"
+```
+
+---
+
+### Task 3: Add message keys and minimal command shell
+
+**TDD scenario:** Modifying tested code — run existing tests first, then add coverage for new behavior
+
+**Files:**
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java`
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/MessageKeySmokeTest.java`
+
+**Step 1: Run the current doctor foundation tests as baseline**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorCheckResultTest' --tests '*DoctorReportTest' --tests '*StatusRendererTest' --tests '*DoctorRendererTest'
+```
+Expected: current focused tests are green before command wiring.
+
+**Step 2: Add message/config keys**
+
+Add defaults for:
+- `info-status-header`
+- `info-status-entry`
+- `info-status-metrics`
+- `info-doctor-header`
+- `info-doctor-entry`
+- `info-doctor-detail`
+- `info-doctor-summary`
+- `syntax.status`
+- `syntax.doctor`
+- `autocomplete.status`
+- `autocomplete.doctor`
+
+Use existing `MessageKeys` patterns so `messages.conf` generation picks them up automatically.
+
+**Step 3: Add minimal `/nexauth status` and `/nexauth doctor` subcommands**
+
+In `NexAuthCommand`:
+- add `@Subcommand("status")`
+- add `@Subcommand("doctor")`
+- both should return `CompletionStage<Void>`
+- both should use `runAsync(() -> { ... })`
+- both should emit rendered lines from the new renderer classes
+
+For this phase, the commands may use placeholder/minimal snapshots and reports rather than full health checks.
+
+**Step 4: Add a light smoke test for new message keys**
+
+Write a small test that exercises the new keys through direct access or constant presence patterns. Do not build a heavy command-manager integration harness yet.
+
+**Step 5: Run the focused tests**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorCheckResultTest' --tests '*DoctorReportTest' --tests '*StatusRendererTest' --tests '*DoctorRendererTest' --tests '*MessageKeySmokeTest'
+```
+Expected: all focused tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java Plugin/src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add doctor and status command shell"
+```
+
+---
+
+### Task 4: Build status snapshot provider for MVP output
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshotProvider.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/StatusSnapshotProviderTest.java`
+
+**Step 1: Write the failing tests**
+
+Cover snapshot fields for:
+- plugin version
+- platform identifier
+- failure policy mode
+- multi-proxy enabled flag
+- email enabled/disabled via handler presence
+- TOTP enabled/disabled via provider presence
+- limbo integration present/absent
+- auth metrics JSON presence
+- proxy data summary presence
+
+Prefer small handwritten stubs/fakes instead of Mockito.
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*StatusSnapshotProviderTest'
+```
+Expected: failing tests because the provider does not exist yet.
+
+**Step 3: Write minimal production code**
+
+Build a provider that converts `AuthenticNexAuth<?, ?>` state into a `StatusSnapshot` without doing any risky I/O.
+
+**Step 4: Run the focused tests to verify they pass**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*StatusSnapshotProviderTest'
+```
+Expected: all focused tests pass.
+
+**Step 5: Update `/nexauth status` to use the real provider**
+
+Replace the placeholder snapshot in `NexAuthCommand` with the provider output.
+
+**Step 6: Run the related focused tests**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*StatusSnapshotProviderTest' --tests '*StatusRendererTest'
+```
+Expected: both pass.
+
+**Step 7: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add status snapshot provider"
+```
+
+---
+
+### Task 5: Add MVP doctor checks
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheck.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheck.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheck.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorService.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheckTest.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheckTest.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheckTest.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorServiceTest.java`
+
+**Step 1: Write the failing tests for individual checks**
+
+Define expected results for:
+- invalid/unknown failure-policy strings defaulting to `HARD_FAIL` but surfacing as a warning
+- database provider or connector missing when one should exist
+- disconnected connector state
+- email enabled/disabled state
+- TOTP provider mismatch (feature expected vs unavailable)
+- limbo integration and proxy data availability
+
+Keep checks read-only and snapshot-driven where possible.
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*ConfigurationDoctorCheckTest' --tests '*DatabaseDoctorCheckTest' --tests '*IntegrationDoctorCheckTest' --tests '*DoctorServiceTest'
+```
+Expected: failing tests because the checks and service do not exist yet.
+
+**Step 3: Write minimal production code**
+
+Implement:
+- check classes that return `DoctorCheckResult`
+- a `DoctorService` that assembles and orders results into a `DoctorReport`
+- snapshot extraction helpers only when needed to avoid excessive command logic
+
+**Step 4: Run the focused tests to verify they pass**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*ConfigurationDoctorCheckTest' --tests '*DatabaseDoctorCheckTest' --tests '*IntegrationDoctorCheckTest' --tests '*DoctorServiceTest'
+```
+Expected: all focused tests pass.
+
+**Step 5: Wire `/nexauth doctor` to the real service**
+
+Update `NexAuthCommand` so `/nexauth doctor` renders the report from `DoctorService`.
+
+**Step 6: Re-run related tests**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorServiceTest' --tests '*DoctorRendererTest' --tests '*StatusSnapshotProviderTest'
+```
+Expected: all pass.
+
+**Step 7: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add doctor mvp health checks"
+```
+
+---
+
+### Task 6: Add support-heavy details and remediation hints
+
+**TDD scenario:** New feature — full TDD cycle
+
+**Files:**
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorCheckResult.java`
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRenderer.java`
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/ConfigurationDoctorCheck.java`
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/DatabaseDoctorCheck.java`
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/checks/IntegrationDoctorCheck.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorRemediationTest.java`
+
+**Step 1: Write the failing tests**
+
+Define expectations for:
+- optional remediation hint text on warning/fail results
+- optional detail lines in verbose rendering
+- summary counts remaining correct when details are present
+
+**Step 2: Run the focused tests to verify they fail**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorRemediationTest' --tests '*DoctorRendererTest' --tests '*DoctorServiceTest'
+```
+Expected: failing tests because remediation/detail support is not implemented yet.
+
+**Step 3: Write minimal production code**
+
+Add optional fields like:
+- detail
+- remediation hint
+- possibly category/check id
+
+Render them only when present.
+
+**Step 4: Run the focused tests to verify they pass**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorRemediationTest' --tests '*DoctorRendererTest' --tests '*DoctorServiceTest'
+```
+Expected: all focused tests pass.
+
+**Step 5: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add remediation hints to doctor output"
+```
+
+---
+
+### Task 7: Integrate status/doctor data into `/nexauth dump`
+
+**TDD scenario:** Modifying tested code — run existing tests first, then add coverage for new behavior
+
+**Files:**
+- Modify: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java`
+- Create: `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/DoctorJsonExporter.java`
+- Create: `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/DoctorJsonExporterTest.java`
+
+**Step 1: Run related tests as baseline**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorServiceTest' --tests '*DoctorRendererTest' --tests '*StatusSnapshotProviderTest'
+```
+Expected: current focused tests are green before dump integration.
+
+**Step 2: Write the failing exporter test**
+
+Define JSON expectations for:
+- top-level doctor/status sections
+- report severity and counts
+- check entries with severity, message, detail, and remediation when present
+- status fields and auth metrics inclusion
+
+**Step 3: Run the focused exporter test to verify it fails**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorJsonExporterTest'
+```
+Expected: failing test because the exporter does not exist yet.
+
+**Step 4: Write minimal production code**
+
+Implement JSON export helpers and update `/nexauth dump` to include:
+- `status`
+- `doctor`
+- existing `authMetrics` retained for backward compatibility if needed
+
+**Step 5: Run the focused dump/export tests**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*DoctorJsonExporterTest' --tests '*DoctorServiceTest' --tests '*StatusSnapshotProviderTest'
+```
+Expected: all focused tests pass.
+
+**Step 6: Commit**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: include doctor and status in dump output"
+```
+
+---
+
+### Task 8: Final verification sweep
+
+**TDD scenario:** Modifying tested code — run existing tests before and after
+
+**Files:**
+- No new files; verification only
+
+**Step 1: Run all doctor/status focused tests**
+
+Run:
+```bash
+./gradlew :Plugin:test --tests '*Doctor*' --tests '*Status*' --tests '*AuthMetricsTest' --tests '*FailurePolicyModeTest'
+```
+Expected: all focused tests pass.
+
+**Step 2: Run the full Plugin test suite**
+
+Run:
+```bash
+./gradlew :Plugin:test
+```
+Expected: Plugin tests pass cleanly.
+
+**Step 3: Run full module verification if Plugin stays green**
+
+Run:
+```bash
+./gradlew :API:test :Plugin:test
+```
+Expected: both modules pass cleanly.
+
+**Step 4: Review scope discipline**
+
+Confirm changes are limited to:
+- `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor/**`
+- `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java`
+- `Plugin/src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java`
+- `Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor/**`
+- no unrelated production edits beyond required wiring
+
+**Step 5: Commit verification checkpoint**
+
+```bash
+git add Plugin/src/main/java/xyz/xreatlabs/nexauth/common/doctor Plugin/src/main/java/xyz/xreatlabs/nexauth/common/command/commands/staff/NexAuthCommand.java Plugin/src/main/java/xyz/xreatlabs/nexauth/common/config/MessageKeys.java Plugin/src/test/java/xyz/xreatlabs/nexauth/common/doctor
+git commit -m "feat: add operator doctor and status system"
+```
+
+---
+
+## Notes for execution
+
+- Keep `/nexauth status` read-only and fast; it should never perform risky network or write operations.
+- Keep `/nexauth doctor` resilient: one failing check should become a failing result, not crash the whole command.
+- Prefer handwritten fakes/stubs in tests instead of Mockito unless test setup becomes clearly unreasonable.
+- If command wiring becomes awkward to test, keep the command methods thinner and move more logic into `StatusSnapshotProvider`, `DoctorService`, renderers, and exporters.
+- If you decide to move the package split toward `common.observability` or `common.reliability`, update this plan consistently before execution rather than mixing namespaces mid-implementation.


### PR DESCRIPTION
## Summary
- add `/nexauth status` and `/nexauth doctor` with structured doctor/status models, renderers, MVP checks, and remediation-ready diagnostics
- extend `/nexauth dump` to include structured doctor and status JSON sections for support/debugging workflows
- add focused unit coverage for doctor/status reports, renderers, checks, status snapshots, and JSON export

## Test Plan
- [x] `./gradlew :Plugin:test --tests '*Doctor*' --tests '*Status*' --tests '*AuthMetricsTest' --tests '*FailurePolicyModeTest'`
- [x] `./gradlew :Plugin:test`
- [x] `./gradlew :API:test :Plugin:test`
